### PR TITLE
Update Optim bounds in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.6
 GeoStatsBase 0.0.5
-Optim 0.14.1
+Optim 0.14.1 0.15.0
 Distances 0.5.0
 SpecialFunctions 0.3.8
 StaticArrays 0.7.0


### PR DESCRIPTION
We have changed the order of inputs for Fminbox to 
```
optimize(objargs..., lower, upper, x0, Fminbox(Solver())
```
from
```
optimize(objargs..., x0, lower, upper, Fminbox{Solver}(), Optim.Options())
```
to be consistent with the new constrained interface
```
optimize(objargs..., constraints..., x0, Method(), Optim.Options())
```