### PR TITLE
EmpiricalVariogram: skip points with 0 distance

### DIFF
--- a/src/empirical.jl
+++ b/src/empirical.jl
@@ -63,6 +63,7 @@ struct EmpiricalVariogram
 
         # evaluate lag and (cross-)variance
         h = evaluate(distance, xi, xj)
+        iszero(h) && continue
         v = (z₁[i] - z₁[j])*(z₂[i] - z₂[j])
 
         # bin (or lag) where to accumulate result

--- a/test/empirical.jl
+++ b/test/empirical.jl
@@ -6,8 +6,8 @@
   @test isnan(y[1]) && y[2] == 0.
   @test n == [0, 3]
 
-  # test spatial data interface
-  sdata = PointSetData(Dict(:z => [1.,0.,1.]), [25. 50. 75.; 25. 75. 50.])
+  # test spatial data interface, includes a duplicate point
+  sdata = PointSetData(Dict(:z => [1.,1.,0.,1.]), [25. 25. 50. 75.; 25. 25. 75. 50.])
   γ = EmpiricalVariogram(sdata, :z, nlags=20, maxlag=1.)
   x, y, n = values(γ)
   @test length(x) == 20


### PR DESCRIPTION
In trying to reproduce the variogram modeling tutorial at https://nbviewer.jupyter.org/github/juliohm/GeoStatsTutorials/blob/master/notebooks/VariogramModeling.ipynb,
I ran into a BoundsError:

```
  BoundsError: attempt to access 20-element Array{Float64,1} at index [0]
  Stacktrace:
   [1] getindex at .\array.jl:742 [inlined]
   [2] EmpiricalVariogram(::PointSetData{Float64,2}, ::Symbol, ::Symbol, ::Int64, ::Float64, ::Distances.Euclidean) at C:\Users\visser_mn\.julia\dev\Variography\src\empirical.jl:73
   [3] #EmpiricalVariogram#1 at C:\Users\visser_mn\.julia\dev\Variography\src\empirical.jl:92 [inlined]
```

Since 1000 samples of all cartesian indices are taken in the tutorial, this may include more than 1 sample of the same point. I'm not sure how you prefer to treat duplicate positions in general, since data may have different measurements on the same position. But skipping when the distance is zero works for me, and avoids the BoundsError which is caused by `ceil(Int, 0)`.