### PR TITLE
use a spatial index in EmpiricalVariogram

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,16 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[compat]
+Distances = "^0.8"
+GeoStatsBase = "^0.6"
+Optim = "^0.18"
+Parameters = "^0.12"
+RecipesBase = "^0.7"
+SpecialFunctions = "^0.7"
+StaticArrays = "^0.11"
+julia = "1"
+
 [extras]
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 GR = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
@@ -24,18 +34,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 QuartzImageIO = "dca85d43-d64c-5e67-8c65-017450d5d020"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 VisualRegressionTests = "34922c18-7c2a-561c-bac1-01e79b2c4c92"
 
 [targets]
-test = ["GeoStatsImages", "Pkg", "GR", "GeoStatsBase", "Test", "DelimitedFiles", "VisualRegressionTests", "LinearAlgebra", "Plots", "ImageMagick", "QuartzImageIO"]
-
-[compat]
-Distances = "^0.8"
-GeoStatsBase = "^0.6"
-Optim = "^0.18"
-Parameters = "^0.12"
-RecipesBase = "^0.7"
-SpecialFunctions = "^0.7"
-StaticArrays = "^0.11"
-julia = "1"
+test = ["GeoStatsImages", "Pkg", "GR", "GeoStatsBase", "Test", "DelimitedFiles", "VisualRegressionTests", "LinearAlgebra", "Plots", "ImageMagick", "QuartzImageIO", "Random"]

--- a/test/empirical.jl
+++ b/test/empirical.jl
@@ -33,6 +33,18 @@
   X = rand(3,2); z = [1, 2, 3]
   @test_throws AssertionError EmpiricalVariogram(X, z)
 
+  # use of spatial index should not affect results
+  Random.seed!(38)
+  n = 2_000
+  X = rand(2, n)
+  z = rand(n)
+  index_d = EmpiricalVariogram(X, z, nlags=20, maxlag=0.05)
+  index_f = EmpiricalVariogram(X, z, nlags=20, maxlag=0.05, nearestsearch=false)
+  index_t = EmpiricalVariogram(X, z, nlags=20, maxlag=0.05, nearestsearch=true)
+  @test index_d.abscissa ≈ index_f.abscissa ≈ index_t.abscissa
+  @test index_d.ordinate ≈ index_f.ordinate ≈ index_t.ordinate
+  @test index_d.counts == index_f.counts == index_t.counts
+
   # directional variogram and known anisotropy ratio
   imgdata = readdlm(joinpath(datadir,"anisotropic.tsv"))
   geodata = RegularGridData{Float64}(Dict(:z => imgdata))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using DelimitedFiles
 using Plots; gr(size=(600,400))
 using VisualRegressionTests
 using Test, Pkg
+using Random
 
 # workaround for GR warnings
 ENV["GKSwstype"] = "100"


### PR DESCRIPTION
If there are many points involved, and the search radius is small relative to the complete domain, using a spatial index is more efficient than iterating over half the points. For one real world dataset this sped up the algorithm about 20x, though of course it greatly varies. Results are identical.

Besides the spatial index, adding an early exit for if `h > hmax` already speeds up the code, avoiding the expensive `v` calculation.

I haven't yet added tests, since we probably want to discuss this first.

There are still some other optimisations that I didn't include here, such as `z₁ = sdata[var₁]; z₂ = sdata[var₂]` creating two distinct vectors even if `var₁ == var₂`, and taking `z₁[j]` and `z₂[j]` `getindex` out of the inner loop.